### PR TITLE
Shorten word to fit button size

### DIFF
--- a/offroad/js/locales/de_DE/messages.po
+++ b/offroad/js/locales/de_DE/messages.po
@@ -462,7 +462,7 @@ msgstr "Alles entfernen"
 
 #: js/components/Settings/Settings.js:505
 msgid "Reset"
-msgstr "Zurücksetzen"
+msgstr "Reset"
 
 #: js/components/Settings/Settings.js:134
 msgid "Resetting calibration requires a reboot."

--- a/offroad/js/locales/de_DE/messages.po
+++ b/offroad/js/locales/de_DE/messages.po
@@ -268,7 +268,7 @@ msgstr "Training beenden"
 
 #: js/components/Settings/Settings.js:538
 msgid "Free Storage"
-msgstr "Kostenloser Speicherplatz"
+msgstr "Freien Speicherplatz"
 
 #: js/components/Settings/Settings.js:679
 msgid "Git Branch"


### PR DESCRIPTION
Currently the German word will cause the last letter to jump to the next line. The word Reset is good enough and should work to fix this small visual issue